### PR TITLE
Update module.json for Foundry Importer

### DIFF
--- a/module.json
+++ b/module.json
@@ -17,9 +17,9 @@
       "name": "William Rotor"
     }
   ],
-  "url": "https://github.com/n7huntsman/fvtt-dnd-5e-outclassed",
-  "manifest": "https://raw.githubusercontent.com/n7huntsman/fvtt-dnd-5e-outclassed/main/module.json",
-  "download": "https://codeload.github.com/n7huntsman/fvtt-dnd-5e-outclassed/zip/main",
+  "url": "https://github.com/rannieryjesuino/fvtt-dnd-5e-outclassed",
+  "manifest": "https://raw.githubusercontent.com/rannieryjesuino/fvtt-dnd-5e-outclassed/main/module.json",
+  "download": "https://codeload.github.com/rannieryjesuino/fvtt-dnd-5e-outclassed/zip/main",
 
   "packs": [
     {

--- a/module.json
+++ b/module.json
@@ -17,7 +17,10 @@
       "name": "William Rotor"
     }
   ],
-  "url": "https://github.com/rannieryjesuino/fvtt-dnd-5e-outclassed",
+  "url": "https://github.com/n7huntsman/fvtt-dnd-5e-outclassed",
+  "manifest": "https://raw.githubusercontent.com/n7huntsman/fvtt-dnd-5e-outclassed/main/module.json",
+  "download": "https://codeload.github.com/n7huntsman/fvtt-dnd-5e-outclassed/zip/main",
+
   "packs": [
     {
       "name": "outclassed-npcs",


### PR DESCRIPTION
Not certain if it's the result of a Foundry version change or what, but Foundry's module importer currently fails to import this module due to a lack of a download link.

I glanced at the module.json files from some other modules on github and found found a couple of links we missing, so I added them. With these changes, it would import from my fork.

The module itself doesn't appear to include token images for the various creatures, but the stats appear correct, at least.